### PR TITLE
Fixed divide by zero error

### DIFF
--- a/arcstat.sh
+++ b/arcstat.sh
@@ -39,9 +39,15 @@ do
 	      	l2miss=`awk '/l2_misses/ {printf $3;}' /proc/spl/kstat/zfs/arcstats`
 	        l2hits=`awk '/l2_hits/ {printf $3;}' /proc/spl/kstat/zfs/arcstats`
 	        l2read=`echo $l2hits+$l2miss|bc`
-	        l2hitp=`echo scale=3\; '100*'$l2hits/$l2read''|bc -l`
-	        cachep=`echo scale=3\; $l2hitp'/100+'$l1hitp|bc -l`
-		diska=`echo scale=3\; '100-'$cachep|bc -l`
+		if [[ $l2read -ne $zero ]]; then
+	        	l2hitp=`echo scale=3\; '100*'$l2hits/$l2read''|bc -l`
+	        	cachep=`echo scale=3\; $l2hitp'/100+'$l1hitp|bc -l`
+			diska=`echo scale=3\; '100-'$cachep|bc -l`
+		else
+			l2hitp="N/A"
+			cachep="N/A"
+			diska="N/A"
+		fi
 
 
 	        printf '\e[33m|\e[0m%-10s %-10s %-10s %-10s %-1s %-3s\e[33m %-2s\e[0m %-10s %-10s %-10s %-10s %-7s %-10s %-7s\e[33m %-1s\e[0m \n' $l1read $l1miss $l1hits $l1hitp% $l1size GB \| $l2read $l2miss $l2hits $l2hitp% ${l2size}GB $diska% \|


### PR DESCRIPTION
Fixed bug where no L2ARC reads had been attempted, it gave a divide byzero error.
